### PR TITLE
Linux Build: add configurable GBDK location, add build scripts for several entries

### DIFF
--- a/AdrianJG/build.sh
+++ b/AdrianJG/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if [ -z "$GBDK_DIR" ]
+then
+      echo "Error: Please set GBDK_DIR environment variable. For example: /"export GBDK_DIR=/opt/gbdk/""
+      exit
+else
+      echo "GBDK_DIR=$GBDK_DIR"
+fi
+
+rm -f AdrianJG/o/*.o
+rm -f AdrianJG/o/*.lst
+rm -f AdrianJG/o/*.asm
+rm -f AdrianJG/o/*.sym
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo6 -c -o AdrianJG/o/adrianJGClockwiseCharacterTiles.o AdrianJG/res/tiles/adrianJGClockwiseCharacterTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo6 -c -o AdrianJG/o/adrianJGClockwiseUIYouTiles.o AdrianJG/res/tiles/adrianJGClockwiseUIYouTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo6 -c -o AdrianJG/o/adrianJGClockwiseArmsTiles.o AdrianJG/res/tiles/adrianJGClockwiseArmsTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo6 -c -o AdrianJG/o/adrianJGHitTheNoteTiles.o AdrianJG/res/tiles/adrianJGHitTheNoteTiles.c
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo6 -c -o AdrianJG/o/adrianJGHitTheNoteBackground.o AdrianJG/res/backgrounds/adrianJGHitTheNoteBackground.c
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo6 -c -o AdrianJG/o/adrianJGClockwiseSong.o AdrianJG/res/audio/adrianJGClockwiseSong.c
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo6 -c -o AdrianJG/o/adrianJGClockwiseMicrogame.o AdrianJG/states/adrianJGClockwiseMicrogame.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo6 -c -o AdrianJG/o/adrianJGHitTheNoteMicrogame.o AdrianJG/states/adrianJGHitTheNoteMicrogame.c

--- a/Bownly/build.sh
+++ b/Bownly/build.sh
@@ -1,42 +1,46 @@
-#!/bin/sh
+#!/bin/bash
 
-BIN=/Users/dovesam/Documents/Development/gbdk/bin
+if [ -z "$GBDK_DIR" ]
+then
+      echo "Error: Please set GBDK_DIR environment variable. For example: /"export GBDK_DIR=/opt/gbdk/""
+      exit
+else
+      echo "GBDK_DIR=$GBDK_DIR"
+fi
 
-echo $BIN
+rm -f Bownly/o/*.o
+rm -f Bownly/o/*.lst
+rm -f Bownly/o/*.asm
+rm -f Bownly/o/*.sym
 
-rm Bownly/o/*.o
-rm Bownly/o/*.lst
-rm Bownly/o/*.asm
-rm Bownly/o/*.sym
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/sfx.o Bownly/sfx.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyVictoryLapSong.o Bownly/res/audio/bownlyVictoryLapSong.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyTheWhiteSong.o Bownly/res/audio/bownlyTheWhiteSong.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyTheWhite2Song.o Bownly/res/audio/bownlyTheWhite2Song.c
 
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/sfx.o Bownly/sfx.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyVictoryLapSong.o Bownly/res/audio/bownlyVictoryLapSong.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyTheWhiteSong.o Bownly/res/audio/bownlyTheWhiteSong.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyTheWhite2Song.o Bownly/res/audio/bownlyTheWhite2Song.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyBowBkgTiles.o Bownly/res/tiles/bownlyBowBkgTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyMP5DiceTiles.o Bownly/res/tiles/bownlyMP5DiceTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyMP5HeartTiles.o Bownly/res/tiles/bownlyMP5HeartTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyMP5StageTiles.o Bownly/res/tiles/bownlyMP5StageTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelBkgTiles.o Bownly/res/tiles/bownlyPastelBkgTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelHeartTiles.o Bownly/res/tiles/bownlyPastelHeartTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelTreeTiles.o Bownly/res/tiles/bownlyPastelTreeTiles.c
 
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyBowBkgTiles.o Bownly/res/tiles/bownlyBowBkgTiles.c 
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyMP5DiceTiles.o Bownly/res/tiles/bownlyMP5DiceTiles.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyMP5HeartTiles.o Bownly/res/tiles/bownlyMP5HeartTiles.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyMP5StageTiles.o Bownly/res/tiles/bownlyMP5StageTiles.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelBkgTiles.o Bownly/res/tiles/bownlyPastelBkgTiles.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelHeartTiles.o Bownly/res/tiles/bownlyPastelHeartTiles.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelTreeTiles.o Bownly/res/tiles/bownlyPastelTreeTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyMP5PanelMaps.o Bownly/res/maps/bownlyMP5PanelMaps.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyMP5StageColMap.o Bownly/res/maps/bownlyMP5StageColMap.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyMP5StageTopMap.o Bownly/res/maps/bownlyMP5StageTopMap.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelBkg1Map.o Bownly/res/maps/bownlyPastelBkg1Map.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelBkg2Map.o Bownly/res/maps/bownlyPastelBkg2Map.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelBkg3Map.o Bownly/res/maps/bownlyPastelBkg3Map.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelTreeMap.o Bownly/res/maps/bownlyPastelTreeMap.c
 
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyMP5PanelMaps.o Bownly/res/maps/bownlyMP5PanelMaps.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyMP5StageColMap.o Bownly/res/maps/bownlyMP5StageColMap.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyMP5StageTopMap.o Bownly/res/maps/bownlyMP5StageTopMap.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelBkg1Map.o Bownly/res/maps/bownlyPastelBkg1Map.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelBkg2Map.o Bownly/res/maps/bownlyPastelBkg2Map.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelBkg3Map.o Bownly/res/maps/bownlyPastelBkg3Map.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelTreeMap.o Bownly/res/maps/bownlyPastelTreeMap.c
+$GBDK_DIR/bin/png2asset Bownly/res/sprites/bownlySprArrow.png -spr8x8 -sw 32 -sh 8 -b 2
+$GBDK_DIR/bin/png2asset Bownly/res/sprites/bownlySprBow.png -spr8x8 -sw 24 -sh 32 -b 2
+$GBDK_DIR/bin/png2asset Bownly/res/sprites/bownlySprTarget.png -spr8x8 -sw 24 -sh 32 -b 2
+$GBDK_DIR/bin/png2asset Bownly/res/sprites/bownlySprPastel.png -spr8x8 -sw 32 -sh 32 -b 2 -py 0
+$GBDK_DIR/bin/png2asset Bownly/res/sprites/bownlySprJumppuff.png -spr8x8 -sw 16 -b 2 -py 0
+$GBDK_DIR/bin/png2asset Bownly/res/sprites/bownlySprPreston.png -spr8x8 -sw 16 -sh 16 -b 2 -py 0 -px 0
 
-$BIN/png2asset Bownly/res/sprites/bownlySprArrow.png -spr8x8 -sw 32 -sh 8 -b 2
-$BIN/png2asset Bownly/res/sprites/bownlySprBow.png -spr8x8 -sw 24 -sh 32 -b 2
-$BIN/png2asset Bownly/res/sprites/bownlySprTarget.png -spr8x8 -sw 24 -sh 32 -b 2
-$BIN/png2asset Bownly/res/sprites/bownlySprPastel.png -spr8x8 -sw 32 -sh 32 -b 2 -py 0
-$BIN/png2asset Bownly/res/sprites/bownlySprJumppuff.png -spr8x8 -sw 16 -b 2 -py 0
-$BIN/png2asset Bownly/res/sprites/bownlySprPreston.png -spr8x8 -sw 16 -sh 16 -b 2 -py 0 -px 0
-
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyBowMicrogame.o Bownly/states/bownlyBowMicrogame.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyMP5Microgame.o Bownly/states/bownlyMP5Microgame.c
-$BIN/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelMicrogame.o Bownly/states/bownlyPastelMicrogame.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyBowMicrogame.o Bownly/states/bownlyBowMicrogame.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyMP5Microgame.o Bownly/states/bownlyMP5Microgame.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo2 -c -o Bownly/o/bownlyPastelMicrogame.o Bownly/states/bownlyPastelMicrogame.c

--- a/Engine/build.sh
+++ b/Engine/build.sh
@@ -1,39 +1,49 @@
-rm Engine/o/*.o
-rm Engine/o/*.lst
-rm Engine/o/*.asm
-rm Engine/o/*.sym
+#!/bin/bash
+
+if [ -z "$GBDK_DIR" ]
+then
+      echo "Error: Please set GBDK_DIR environment variable. For example: /"export GBDK_DIR=/opt/gbdk/""
+      exit
+else
+      echo "GBDK_DIR=$GBDK_DIR"
+fi
+
+rm -f Engine/o/*.o
+rm -f Engine/o/*.lst
+rm -f Engine/o/*.asm
+rm -f Engine/o/*.sym
 
 BIN=/Users/dovesam/Documents/Development/gbdk/bin
 
-$BIN/lcc -Wa-l -c -o Engine/o/borderTiles.o Engine/res/tiles/borderTiles.c
-$BIN/lcc -Wa-l -c -o Engine/o/fontTiles.o Engine/res/tiles/fontTiles.c
-$BIN/lcc -Wa-l -c -o Engine/o/timerTiles.o Engine/res/tiles/timerTiles.c
-$BIN/lcc -Wa-l -Wf-bo1 -c -o Engine/o/engineDMGTiles.o Engine/res/tiles/engineDMGTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -c -o Engine/o/borderTiles.o Engine/res/tiles/borderTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -c -o Engine/o/fontTiles.o Engine/res/tiles/fontTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -c -o Engine/o/timerTiles.o Engine/res/tiles/timerTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o Engine/o/engineDMGTiles.o Engine/res/tiles/engineDMGTiles.c
 
-$BIN/lcc -Wa-l -Wf-bo1 -c -o Engine/o/engineDMGBat0Map.o Engine/res/maps/engineDMGBat0Map.c
-$BIN/lcc -Wa-l -Wf-bo1 -c -o Engine/o/engineDMGBat1Map.o Engine/res/maps/engineDMGBat1Map.c
-$BIN/lcc -Wa-l -Wf-bo1 -c -o Engine/o/engineDMGBat2Map.o Engine/res/maps/engineDMGBat2Map.c
-$BIN/lcc -Wa-l -Wf-bo1 -c -o Engine/o/engineDMGBat3Map.o Engine/res/maps/engineDMGBat3Map.c
-$BIN/lcc -Wa-l -Wf-bo1 -c -o Engine/o/engineDMGBat4Map.o Engine/res/maps/engineDMGBat4Map.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o Engine/o/engineDMGBat0Map.o Engine/res/maps/engineDMGBat0Map.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o Engine/o/engineDMGBat1Map.o Engine/res/maps/engineDMGBat1Map.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o Engine/o/engineDMGBat2Map.o Engine/res/maps/engineDMGBat2Map.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o Engine/o/engineDMGBat3Map.o Engine/res/maps/engineDMGBat3Map.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o Engine/o/engineDMGBat4Map.o Engine/res/maps/engineDMGBat4Map.c
 
-$BIN/lcc -Wa-l -Wf-bo1 -Wf-bo1 -c -o Engine/o/premgJingle.o Engine/res/audio/premgJingle.c
-$BIN/lcc -Wa-l -Wf-bo1 -Wf-bo1 -c -o Engine/o/lostJingle.o Engine/res/audio/lostJingle.c
-$BIN/lcc -Wa-l -Wf-bo1 -Wf-bo1 -c -o Engine/o/wonJingle.o Engine/res/audio/wonJingle.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -Wf-bo1 -c -o Engine/o/premgJingle.o Engine/res/audio/premgJingle.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -Wf-bo1 -c -o Engine/o/lostJingle.o Engine/res/audio/lostJingle.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -Wf-bo1 -c -o Engine/o/wonJingle.o Engine/res/audio/wonJingle.c
 
-$BIN/lcc -Wa-l -c -o Engine/o/common.o Engine/common.c
-$BIN/lcc -Wa-l -c -o Engine/o/fade.o Engine/fade.c
-$BIN/lcc -Wa-l -c -o Engine/o/songPlayer.o Engine/songPlayer.c
+$GBDK_DIR/bin/lcc -Wa-l -c -o Engine/o/common.o Engine/common.c
+$GBDK_DIR/bin/lcc -Wa-l -c -o Engine/o/fade.o Engine/fade.c
+$GBDK_DIR/bin/lcc -Wa-l -c -o Engine/o/songPlayer.o Engine/songPlayer.c
 
-$BIN/lcc -Wa-l -c -o Engine/o/microgameData.o Engine/database/microgameData.c
+$GBDK_DIR/bin/lcc -Wa-l -c -o Engine/o/microgameData.o Engine/database/microgameData.c
 
-$BIN/png2asset Engine/res/sprites/engineGBCart.png -spr8x8 -sw 8 -sh 8 -b 1 -map -tile_origin 64 -noflip
-$BIN/png2asset Engine/res/sprites/engineDMGBezel.png -spr8x8 -sw 8 -sh 8 -b 1 -map -tile_origin 144 -noflip
+$GBDK_DIR/bin/png2asset Engine/res/sprites/engineGBCart.png -spr8x8 -sw 8 -sh 8 -b 1 -map -tile_origin 64 -noflip
+$GBDK_DIR/bin/png2asset Engine/res/sprites/engineDMGBezel.png -spr8x8 -sw 8 -sh 8 -b 1 -map -tile_origin 144 -noflip
 
-$BIN/lcc -Wa-l -Wf-bo0 -c -o Engine/o/microgameManagerState.o Engine/states/microgameManagerState.c
-$BIN/lcc -Wa-l -Wf-bo1 -c -o Engine/o/titleState.o Engine/states/titleState.c
-$BIN/lcc -Wa-l -Wf-bo1 -c -o Engine/o/gameoverState.o Engine/states/gameoverState.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo0 -c -o Engine/o/microgameManagerState.o Engine/states/microgameManagerState.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o Engine/o/titleState.o Engine/states/titleState.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o Engine/o/gameoverState.o Engine/states/gameoverState.c
 
-$BIN/lcc -Wa-l -Wf-ba0 -c -o Engine/o/ram.o Engine/ram.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-ba0 -c -o Engine/o/ram.o Engine/ram.c
 
 
 # @REM During/post gamejam TODO broadstrokes:

--- a/SynchingFeeling/build.sh
+++ b/SynchingFeeling/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if [ -z "$GBDK_DIR" ]
+then
+      echo "Error: Please set GBDK_DIR environment variable. For example: /"export GBDK_DIR=/opt/gbdk/""
+      exit
+else
+      echo "GBDK_DIR=$GBDK_DIR"
+fi
+
+rm -f SynchingFeeling/o/*.o
+rm -f SynchingFeeling/o/*.lst
+rm -f SynchingFeeling/o/*.asm
+rm -f SynchingFeeling/o/*.sym
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o SynchingFeeling/o/sfx.o SynchingFeeling/sfx.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o SynchingFeeling/o/synchingFeelingHumptyDumptySong.o SynchingFeeling/res/audio/synchingFeelingHumptyDumptySong.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o SynchingFeeling/o/sloopyGoopSingingMushroomSong.o SynchingFeeling/res/audio/sloopyGoopSingingMushroomSong.c
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o SynchingFeeling/o/synchingFeelingEggTiles.o SynchingFeeling/res/tiles/synchingFeelingEggTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o SynchingFeeling/o/synchingFeelingEggMaps.o SynchingFeeling/res/maps/synchingFeelingEggMaps.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o SynchingFeeling/o/synchingFeelingGhostTiles.o SynchingFeeling/res/tiles/synchingFeelingGhostTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o SynchingFeeling/o/synchingFeelingGhostMaps.o SynchingFeeling/res/maps/synchingFeelingGhostMaps.c
+
+$GBDK_DIR/bin/png2asset SynchingFeeling/res/sprites/synchingFeelingEggSpr.png -spr8x8 -sw 16 -sh 16 -b 11
+$GBDK_DIR/bin/png2asset SynchingFeeling/res/sprites/synchingFeelingBlockSpr.png -spr8x8 -sw 16 -sh 16 -b 11
+$GBDK_DIR/bin/png2asset SynchingFeeling/res/sprites/synchingFeelingCoinSpr.png -spr8x8 -sw 16 -sh 16 -b 11
+$GBDK_DIR/bin/png2asset SynchingFeeling/res/sprites/synchingFeelingGhostSpr.png -spr8x8 -sw 16 -sh 16 -b 11
+$GBDK_DIR/bin/png2asset SynchingFeeling/res/sprites/synchingFeelingEyeSpr.png -spr8x8 -sw 16 -sh 16 -b 11
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o SynchingFeeling/o/synchingFeelingEggMicrogame.o SynchingFeeling/states/synchingFeelingEggMicrogame.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o SynchingFeeling/o/synchingFeelingGhostMicrogame.o SynchingFeeling/states/synchingFeelingGhostMicrogame.c

--- a/Template/build.sh
+++ b/Template/build.sh
@@ -1,20 +1,28 @@
-rm Template/o/*.o
-rm Template/o/*.lst
-rm Template/o/*.asm
-rm Template/o/*.sym
+#!/bin/bash
 
-BIN=/Users/dovesam/Documents/Development/gbdk/bin
+if [ -z "$GBDK_DIR" ]
+then
+      echo "Error: Please set GBDK_DIR environment variable. For example: /"export GBDK_DIR=/opt/gbdk/""
+      exit
+else
+      echo "GBDK_DIR=$GBDK_DIR"
+fi
+
+rm -f Template/o/*.o
+rm -f Template/o/*.lst
+rm -f Template/o/*.asm
+rm -f Template/o/*.sym
 
 
-$BIN/lcc -Wa-l -Wf-bo1 -c -o Template/o/templateCursorTiles.o Template/res/tiles/templateCursorTiles.c
-$BIN/lcc -Wa-l -Wf-bo1 -c -o Template/o/templateFaceTiles.o Template/res/tiles/templateFaceTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o Template/o/templateCursorTiles.o Template/res/tiles/templateCursorTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o Template/o/templateFaceTiles.o Template/res/tiles/templateFaceTiles.c
 
-$BIN/lcc -Wa-l -Wf-bo1 -c -o Template/o/templateFace1Map.o Template/res/maps/templateFace1Map.c
-$BIN/lcc -Wa-l -Wf-bo1 -c -o Template/o/templateFace2Map.o Template/res/maps/templateFace2Map.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o Template/o/templateFace1Map.o Template/res/maps/templateFace1Map.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o Template/o/templateFace2Map.o Template/res/maps/templateFace2Map.c
 
-$BIN/lcc -Wa-l -Wf-bo1 -c -o Template/o/templateTwilightDriveSong.o Template/res/audio/templateTwilightDriveSong.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o Template/o/templateTwilightDriveSong.o Template/res/audio/templateTwilightDriveSong.c
 
-$BIN/lcc -Wa-l -Wf-bo1 -c -o Template/o/templateFaceMicrogame.o Template/states/templateFaceMicrogame.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o Template/o/templateFaceMicrogame.o Template/states/templateFaceMicrogame.c
 
 # @REM TODO:
 # @REM Screenshake?

--- a/bbbbbr/build.sh
+++ b/bbbbbr/build.sh
@@ -9,10 +9,10 @@ else
 fi
 
 mkdir -p bbbbbr/o
-rm -rf bbbbbr/o/*.o
-rm -rf bbbbbr/o/*.lst
-rm -rf bbbbbr/o/*.asm
-rm -rf bbbbbr/o/*.sym
+rm -f bbbbbr/o/*.o
+rm -f bbbbbr/o/*.lst
+rm -f bbbbbr/o/*.asm
+rm -f bbbbbr/o/*.sym
 
 # No music for now
 # $GBDK_DIR/bin/lcc -Wa-l -Wf-bo13 -c -o bbbbbr/o/bbbbbrSomeSong.o bbbbbr/res/audio/bbbbbrSomeSong.c

--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,34 @@
-#!/bin/sh
+#!/bin/bash
 
-BIN=/Users/dovesam/Documents/Development/gbdk/bin
+if [ -z "$GBDK_DIR" ]
+then
+      echo "Error: Please set GBDK_DIR environment variable. For example: /"export GBDK_DIR=/opt/gbdk/""
+      exit
+else
+      echo "GBDK_DIR=$GBDK_DIR"
+fi
 
 source Engine/build.sh
 source Bownly/build.sh
 source Template/build.sh
+source teaaaaaaaa/build.sh
 source dovesam/build.sh
+source joaomakesgames/build.sh
+source oshf/build.sh
+source AdrianJG/build.sh
+source SynchingFeeling/build.sh
+source bbbbbr/build.sh
 
-$BIN/lcc -Wa-l -c -o Engine/o/main.o main.c
-$BIN/lcc -Wl-yt3 -Wl-yo8 -Wl-ya4 -o GBMicroGames.gb \
-    hUGETracker/hUGEDriver.obj.o                \
-    Engine/o/*.o Engine/res/sprites/*.c         \
-    Bownly/o/*.o Bownly/res/sprites/*.c         \
-    Template/o/*.o                              \
-    dovesam/o/*.o dovesam/res/assets/*.c
+$GBDK_DIR/bin/lcc -Wa-l -c -o Engine/o/main.o main.c
+$GBDK_DIR/bin/lcc -Wl-yt3 -Wl-yoA -Wl-ya4 -o GBMicroGames.gb \
+	hUGETracker/hUGEDriver.obj.o                          \
+	Engine/o/*.o Engine/res/sprites/*.c                   \
+	Bownly/o/*.o Bownly/res/sprites/*.c                   \
+	teaaaaaaaa/o/*.o                                      \
+	dovesam/o/*.o dovesam/res/assets/*.c                  \
+	joaomakesgames/o/*.o                                  \
+	oshf/o/*.o                                            \
+	AdrianJG/o/*.o                                        \
+	SynchingFeeling/o/*.o SynchingFeeling/res/sprites/*.c \
+	Template/o/*.o                                        \
+	bbbbbr/o/*.o

--- a/dovesam/build.sh
+++ b/dovesam/build.sh
@@ -1,25 +1,34 @@
-rm dovesam/o/*.o
-rm dovesam/o/*.lst
-rm dovesam/o/*.asm
-rm dovesam/o/*.sym
-rm dovesam/res/assets/*.c
-rm dovesam/res/assets/*.h
+#!/bin/bash
 
-BIN=/Users/dovesam/Documents/Development/gbdk/bin
+if [ -z "$GBDK_DIR" ]
+then
+      echo "Error: Please set GBDK_DIR environment variable. For example: /"export GBDK_DIR=/opt/gbdk/""
+      exit
+else
+      echo "GBDK_DIR=$GBDK_DIR"
+fi
+
+rm -f dovesam/o/*.o
+rm -f dovesam/o/*.lst
+rm -f dovesam/o/*.asm
+rm -f dovesam/o/*.sym
+rm -f dovesam/res/assets/*.c
+rm -f dovesam/res/assets/*.h
+
 BANK=7
 ASSETS=dovesam/res/assets
 SPRITES=dovesam/res/sprites
 MAPS=dovesam/res/raw_maps
 
-$BIN/png2asset $SPRITES/dovesamPaddleSpriteSheet.png -spr8x8 -sw 32 -sh 8 -b $BANK -c $ASSETS/dovesamPaddleSpriteSheet.c
-$BIN/png2asset $SPRITES/dovesamBallSprite.png -spr8x8 -sw 8 -sh 8 -b $BANK -c $ASSETS/dovesamBallSprite.c
+$GBDK_DIR/bin/png2asset $SPRITES/dovesamPaddleSpriteSheet.png -spr8x8 -sw 32 -sh 8 -b $BANK -c $ASSETS/dovesamPaddleSpriteSheet.c
+$GBDK_DIR/bin/png2asset $SPRITES/dovesamBallSprite.png -spr8x8 -sw 8 -sh 8 -b $BANK -c $ASSETS/dovesamBallSprite.c
 
-$BIN/png2asset $MAPS/dovesamPaddleArena.png -map -noflip -bpp 2 -max_palettes 1 -pack_mode gb -b $BANK -c \
+$GBDK_DIR/bin/png2asset $MAPS/dovesamPaddleArena.png -map -noflip -bpp 2 -max_palettes 1 -pack_mode gb -b $BANK -c \
     $ASSETS/dovesamPaddleArena.c
-$BIN/png2asset $MAPS/dovesamButtons.png -map -noflip -bpp 2 -max_palettes 1 -pack_mode gb -b $BANK -c $ASSETS/dovesamButtons.c
+$GBDK_DIR/bin/png2asset $MAPS/dovesamButtons.png -map -noflip -bpp 2 -max_palettes 1 -pack_mode gb -b $BANK -c $ASSETS/dovesamButtons.c
 
-$BIN/lcc -Wa-l -Wf-bo$BANK -c -o dovesam/o/dovesamPaddleMicrogame.o dovesam/states/dovesamPaddleMicrogame.c
-$BIN/lcc -Wa-l -Wf-bo$BANK -c -o dovesam/o/dovesamCodeCrackMicrogame.o dovesam/states/dovesamCodeCrackMicrogame.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo$BANK -c -o dovesam/o/dovesamPaddleMicrogame.o dovesam/states/dovesamPaddleMicrogame.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo$BANK -c -o dovesam/o/dovesamCodeCrackMicrogame.o dovesam/states/dovesamCodeCrackMicrogame.c
 
 # @REM TODO:
 # @REM Screenshake?

--- a/joaomakesgames/build.sh
+++ b/joaomakesgames/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [ -z "$GBDK_DIR" ]
+then
+      echo "Error: Please set GBDK_DIR environment variable. For example: /"export GBDK_DIR=/opt/gbdk/""
+      exit
+else
+      echo "GBDK_DIR=$GBDK_DIR"
+fi
+
+rm -f joaomakesgames/o/*.o
+rm -f joaomakesgames/o/*.lst
+rm -f joaomakesgames/o/*.asm
+rm -f joaomakesgames/o/*.sym
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o joaomakesgames/o/sound.o joaomakesgames/sound.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o joaomakesgames/o/BalloonsPopping.o joaomakesgames/resources/sprites/BalloonsPopping.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o joaomakesgames/o/ThumbsUp.o joaomakesgames/resources/sprites/ThumbsUp.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o joaomakesgames/o/Ui.o joaomakesgames/resources/sprites/Ui.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o joaomakesgames/o/Aim.o joaomakesgames/resources/sprites/Aim.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o joaomakesgames/o/Balloons.o joaomakesgames/resources/sprites/Balloons.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o joaomakesgames/o/BackgroundTiles.o joaomakesgames/resources/background/BackgroundTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o joaomakesgames/o/Background.o joaomakesgames/resources/background/Background.c
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo11 -c -o joaomakesgames/o/saveTheKidsMicrogame.o joaomakesgames/states/saveTheKidsMicrogame.c

--- a/oshf/build.sh
+++ b/oshf/build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+if [ -z "$GBDK_DIR" ]
+then
+      echo "Error: Please set GBDK_DIR environment variable. For example: /"export GBDK_DIR=/opt/gbdk/""
+      exit
+else
+      echo "GBDK_DIR=$GBDK_DIR"
+fi
+
+rm -f oshf/o/*.o
+rm -f oshf/o/*.lst
+rm -f oshf/o/*.asm
+rm -f oshf/o/*.sym
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfTwilightDriveSong.o oshf/res/audio/oshfTwilightDriveSong.c
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfRPSTiles.o oshf/res/tiles/oshfRPSTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfRPSArrow.o oshf/res/tiles/oshfRPSArrow.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfRPSLCloud.o oshf/res/tiles/oshfRPSLCloud.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfRPSRCloud.o oshf/res/tiles/oshfRPSRCloud.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfRPSNinjaR.o oshf/res/tiles/oshfRPSNinjaR.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfRPSNinjaP.o oshf/res/tiles/oshfRPSNinjaP.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfRPSNinjaS.o oshf/res/tiles/oshfRPSNinjaS.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfRPSNinjaDefeat.o oshf/res/tiles/oshfRPSNinjaDefeat.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfRPSNinjaWin.o oshf/res/tiles/oshfRPSNinjaWin.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfRPSMap.o oshf/res/maps/oshfRPSMap.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfRPSR.o oshf/res/maps/oshfRPSR.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfRPSP.o oshf/res/maps/oshfRPSP.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfRPSS.o oshf/res/maps/oshfRPSS.c
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfRPSMicrogame.o oshf/states/oshfRPSMicrogame.c
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfHBTiles.o oshf/res/tiles/oshfHBTiles.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfHBBird.o oshf/res/tiles/oshfHBBird.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfHBSad.o oshf/res/tiles/oshfHBSad.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfHBHappy.o oshf/res/tiles/oshfHBHappy.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfHBJump.o oshf/res/tiles/oshfHBJump.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfHBWorm.o oshf/res/tiles/oshfHBWorm.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfHBMap.o oshf/res/maps/oshfHBMap.c
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo1 -c -o oshf/o/oshfHBMicrogame.o oshf/states/oshfHBMicrogame.c

--- a/teaaaaaaaa/build.sh
+++ b/teaaaaaaaa/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ -z "$GBDK_DIR" ]
+then
+      echo "Error: Please set GBDK_DIR environment variable. For example: /"export GBDK_DIR=/opt/gbdk/""
+      exit
+else
+      echo "GBDK_DIR=$GBDK_DIR"
+fi
+
+rm -f teaaaaaaaa/o/*.o
+rm -f teaaaaaaaa/o/*.lst
+rm -f teaaaaaaaa/o/*.asm
+rm -f teaaaaaaaa/o/*.sym
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo8 -c -o teaaaaaaaa/o/WhackMoleSpriteGraphics.o teaaaaaaaa/res/tiles/WhackMoleSpriteGraphics.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo8 -c -o teaaaaaaaa/o/WhackMoleSpriteTileData.o teaaaaaaaa/res/tiles/WhackMoleSpriteTileData.c
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo8 -c -o teaaaaaaaa/o/WhackMoleBGgraphics.o teaaaaaaaa/res/tiles/WhackMoleBGgraphics.c
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo8 -c -o teaaaaaaaa/o/whackMolesBG.o teaaaaaaaa/res/maps/whackMolesBG.c
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo8 -Wf-bo8 -c -o teaaaaaaaa/o/whackMolesMusic.o teaaaaaaaa/res/audio/whackMolesMusic.c
+
+$GBDK_DIR/bin/lcc -Wa-l -Wf-bo8 -c -o teaaaaaaaa/o/templateFaceMicrogame.o teaaaaaaaa/states/templateFaceMicrogame.c


### PR DESCRIPTION
Changes hardwired linux build.sh files GBDK bin path to an environment var.
Adds build.sh for remaining entries.

The environment var should be set like this, for example: `export GBDK_DIR=/opt/gbdk/`
